### PR TITLE
DEXA-178 Bump voxeet:sdk to 3.3.0-beta.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,9 @@ repositories {
     maven {
         url("http://android-sdk.voxeet.com/release")
     }
+    maven {
+      url("http://android-sdk.voxeet.com/beta")
+    }
     google()
     mavenCentral()
     maven {
@@ -70,7 +73,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.annotation:annotation:1.1.0"
 
-    implementation "com.voxeet.sdk:sdk:3.2.3"
+    implementation "com.voxeet.sdk:sdk:3.3.0-beta.1"
 
     testImplementation("junit:junit:${JUNIT_VERSION}")
     testImplementation("org.powermock:powermock-api-mockito2:${POWERMOCK_VERSION}")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.annotation:annotation:1.1.0"
 
-    implementation "com.voxeet.sdk:sdk:3.3.0-beta.1"
+    implementation "com.voxeet.sdk:sdk:3.3.0-beta.2"
 
     testImplementation("junit:junit:${JUNIT_VERSION}")
     testImplementation("org.powermock:powermock-api-mockito2:${POWERMOCK_VERSION}")

--- a/android/src/main/java/io/dolby/sdk/FilePresentationExt.kt
+++ b/android/src/main/java/io/dolby/sdk/FilePresentationExt.kt
@@ -11,7 +11,7 @@ import java.util.HashMap
 fun VoxeetSDK.filePresentation(): FilePresentationService {
   val origin = VoxeetSDK.filePresentation()
   if (!::sdkEnvironmentField.isInitialized) {
-    val field = javaClass.getDeclaredField("_sdk_environment_holder")
+    val field = requireNotNull(javaClass.superclass?.getDeclaredField("_sdk_environment_holder"))
     field.isAccessible = true
     sdkEnvironmentField = field
   }

--- a/android/src/main/java/io/dolby/sdk/reactnative/services/RNSessionServiceModule.kt
+++ b/android/src/main/java/io/dolby/sdk/reactnative/services/RNSessionServiceModule.kt
@@ -84,7 +84,7 @@ class RNSessionServiceModule(
   @ReactMethod
   fun isOpen(promise: Promise) {
     Promises
-      .promise(sessionService.isSocketOpen)
+      .promise(sessionService.isOpen)
       .forward(promise)
   }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -29,6 +29,9 @@ allprojects {
         maven {
             url("http://android-sdk.voxeet.com/release")
         }
+         maven {
+            url("http://android-sdk.voxeet.com/beta")
+        }
         maven {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")


### PR DESCRIPTION
Draft!

After update unable to join conference
```
com.voxeet.android.media.errors.RemoteDescriptionError: Unable set remote SDP for Peer: 6ad4f54f-92df-3d11-8bd8-ed5296457515 :: Failed to set remote offer sdp: Failed to set remote video description send parameters.
	at com.voxeet.sdk.media.MediaSDK.createAnswerForPeer(MediaSDK.java:103)
	at com.voxeet.sdk.services.ConferenceService.lambda$null$75(ConferenceService.java:3224)
	at com.voxeet.sdk.services.-$$Lambda$ConferenceService$qKZgwbh_nuhwDRDy5QfOxPE2TQY.run(Unknown Source:16)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:462)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:919)
```

UPD. Only emulators. Despite invoked method
``` kotlin
private fun enableOnEmulator() {
    CodecDescriptorFactory
      .getEncoders(VideoCodecType.H264)
      ?.register(CodecDescriptor("OMX.google", 16, true))
    CodecDescriptorFactory
      .getDecoders()
      .register(CodecDescriptor("OMX.google", 16, false))
  }
```