### PR TITLE
DEXA-311 - fixed and improved typedoc generated comments

### DIFF
--- a/src/DolbyIoIAPI.ts
+++ b/src/DolbyIoIAPI.ts
@@ -12,7 +12,7 @@ import MediaDeviceService from './services/mediaDevice/MediaDeviceService';
 import NotificationService from './services/notification/NotificationService';
 import RecordingService from './services/recording/RecordingService';
 import SessionService from './services/session/SessionService';
-import VideoPresentationService from './services/videoPresentation/VideoPresentation';
+import VideoPresentationService from './services/videoPresentation/VideoPresentationService';
 import Logger from './utils/Logger';
 import NativeEvents from './utils/NativeEvents';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,6 @@ export { default as MediaDevice } from './services/mediaDevice/MediaDeviceServic
 export { default as Notification } from './services/notification/NotificationService';
 export { default as Recording } from './services/recording/RecordingService';
 export { default as Session } from './services/session/SessionService';
-export { default as VideoPresentation } from './services/videoPresentation/VideoPresentation';
+export { default as VideoPresentation } from './services/videoPresentation/VideoPresentationService';
 
 export { default as VideoView } from './VideoView/VideoView';

--- a/src/services/command/CommandService.ts
+++ b/src/services/command/CommandService.ts
@@ -7,7 +7,6 @@ import { CommandServiceEventNames } from './events';
 const { DolbyIoIAPICommandServiceModule } = NativeModules;
 
 /**
- * @class CommandService
 The Command service allows the application to send text messages or notifications to all conference participants.
 The service also emits an received event to inform the application about received messages.
  */
@@ -19,7 +18,7 @@ export class CommandService {
 
   /**
    * Sends a message, in the form of a basic stream, to all conference participants.
-   * @param message<string> Message to send
+   * @param message Message to send
    */
   public async send(message: string): Promise<void> {
     return this._nativeModule.send(message);
@@ -27,8 +26,8 @@ export class CommandService {
 
   /**
    * Adds a native listener for message received
-   * @param handler<(data: MessageReceivedEventType) => void> Handling function
-   * @returns {() => void} Function that removes handler
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
   public onMessageReceived(
     handler: (data: MessageReceivedEventType) => void

--- a/src/services/conference/ConferenceService.ts
+++ b/src/services/conference/ConferenceService.ts
@@ -31,6 +31,10 @@ import { transformToConference, transformToParticipant } from './transformers';
 
 const { DolbyIoIAPIConferenceService } = NativeModules;
 
+/**
+ * The ConferenceService allows the application to manage the conference
+ * life-cycle and interact with the conference.
+ */
 export class ConferenceService {
   /** @internal */
   _nativeModule = DolbyIoIAPIConferenceService;
@@ -39,10 +43,8 @@ export class ConferenceService {
 
   /**
    * Create a conference with options
-   * @param options<CreateOptions> The conference options
-   * @returns {Promise<Conference>} Promise with a Conference object
+   * @param options The conference options
    */
-
   public async create(
     options: ConferenceCreateOptions = {}
   ): Promise<Conference> {
@@ -51,30 +53,24 @@ export class ConferenceService {
 
   /**
    * Provides a Conference object that allows joining a conference. Without a param it returns current Conference object.
-   * @param conferenceId?<string> The conference ID.
-   * @returns {Promise<Conference>} Promise with a Conference object
+   * @param conferenceId The conference ID.
    */
-
   public async fetch(conferenceId?: string): Promise<Conference> {
     return transformToConference(await this._nativeModule.fetch(conferenceId));
   }
 
   /**
    * Provides information about the current conference.
-   * @returns {Promise<Conference>} Promise with a Conference object
    */
-
   public async current(): Promise<Conference> {
     return transformToConference(await this._nativeModule.current());
   }
 
   /**
    * Replays a previously recorded conference.
-   * @param conference<Conference> The Conference.
-   * @param replayOptions<ConferenceReplayOptions> The replay options.
-   * @returns {Promise<Conference>} Promise with a Conference object
+   * @param conference Conference object.
+   * @param replayOptions Replay options.
    */
-
   public async replay(
     conference: Conference,
     replayOptions?: ConferenceReplayOptions
@@ -89,38 +85,30 @@ export class ConferenceService {
 
   /**
    * Gets the participant's audio level
-   * @param participant<Participant> The participant object.
-   * @returns {Promise<AudioLevel>} Promise with AudioLevel
+   * @param participant The participant object.
    */
-
   public async getAudioLevel(participant: Participant): Promise<AudioLevel> {
     return this._nativeModule.getAudioLevel(participant);
   }
 
   /**
    * Provides standard WebRTC statistics for the application.
-   * @returns {Promise<RTCStatsType>} Promise with LocalStats
    */
-
   public async getLocalStats(): Promise<RTCStatsType[]> {
     return this._nativeModule.getLocalStats();
   }
 
   /**
    * Provides the number of video streams that are transmitted to the local user.
-   * @returns {Promise<MaxVideoForwarding>} Promise with MaxVideoForwarding
    */
-
   public async getMaxVideoForwarding(): Promise<MaxVideoForwarding> {
     return this._nativeModule.getMaxVideoForwarding();
   }
 
   /**
    * The participant's information.
-   * @param participantId<string> ID of Participant
-   * @returns {Promise<Participant>} Promise with Participant
+   * @param participantId ID of Participant.
    */
-
   public async getParticipant(participantId: String): Promise<Participant> {
     return transformToParticipant(
       await this._nativeModule.getParticipant(participantId)
@@ -130,9 +118,7 @@ export class ConferenceService {
   /**
    * Gets a list of conference participants
    * @param conference<Conference> The Conference object.
-   * @returns {Promise<Array<Participant>>} Promise with array of Participants
    */
-
   public async getParticipants(
     conference: Conference
   ): Promise<Array<Participant>> {
@@ -142,48 +128,40 @@ export class ConferenceService {
 
   /**
    * Provides the conference status.
-   * @param conference<Conference> The Conference object.
-   * @returns {Promise<ConferenceStatus>} Promise with a ConferenceStatus string
+   * @param conference The Conference object.
    */
-
   public async getStatus(conference: Conference): Promise<ConferenceStatus> {
     return this._nativeModule.getStatus(conference);
   }
 
   /**
    * Informs whether the application plays the remote participants' audio to the local participant.
-   * @returns {Promise<boolean>} A boolean indicating whether the application plays the remote participants' audio to the local participant.
+   * @returns A boolean indicating whether the application plays the remote participants' audio to the local participant.
    */
-
   public async isOutputMuted(): Promise<boolean> {
     return !!(await this._nativeModule.isOutputMuted());
   }
 
   /**
    * Gets the current mute state of the participant.
-   * @returns {Promise<boolean>} Information if the local participant is muted.
+   * @returns Information if the local participant is muted.
    */
-
   public async isMuted(): Promise<boolean> {
     return this._nativeModule.isMuted();
   }
 
   /**
    * Gets the participant's current speaking status for an active talker indicator.
-   * @param participant<Participant> The Participant object.
-   * @returns {Promise<boolean>} A boolean indicating whether the current participant is speaking.
+   * @param participant The Participant object.
    */
-
   public async isSpeaking(participant: Participant): Promise<boolean> {
     return this._nativeModule.isSpeaking(participant);
   }
 
   /**
    * Enables and disables audio processing for the conference participant.
-   * @param options<AudioProcessingOptions> The AudioProcessingOptions model includes the AudioProcessingSenderOptions model responsible for enabling and disabling audio processing.
-   * @returns {Promise<void>}
+   * @param options The AudioProcessingOptions model includes the AudioProcessingSenderOptions model responsible for enabling and disabling audio processing.
    */
-
   public async setAudioProcessing(
     options: AudioProcessingOptions = {}
   ): Promise<void> {
@@ -192,11 +170,9 @@ export class ConferenceService {
 
   /**
    * Sets the maximum number of video streams that may be transmitted to the local participant.
-   * @param max<MaxVideoForwarding> The maximum number of video streams that may be transmitted to the local participant. The valid parameter's values are between 0 and 4 for mobile browsers with 4 as default value.
-   * @param prioritizedParticipants<Participant[]> The list of the prioritized participants. This parameter allows using a pin option to prioritize specific participant's video streams and display their videos even when these participants do not talk.
-   * @returns {Promise<any>}
+   * @param max The maximum number of video streams that may be transmitted to the local participant. The valid parameter's values are between 0 and 4 for mobile browsers with 4 as default value.
+   * @param prioritizedParticipants The list of the prioritized participants. This parameter allows using a pin option to prioritize specific participant's video streams and display their videos even when these participants do not talk.
    */
-
   public async setMaxVideoForwarding(
     max: MaxVideoForwarding = 4,
     prioritizedParticipants: Participant[] = []
@@ -209,11 +185,10 @@ export class ConferenceService {
 
   /**
    * Stops playing the specified remote participants' audio to the local participant or stops playing the local participant's audio to the conference.
-   * @param isMuted<boolean> A boolean, true indicates that the local participant is muted, false indicates that a participant is not muted
-   * @param participant<Participant> A remote participant
-   * @returns {Promise<boolean>} Informs if the mute state has changed.
+   * @param isMuted A boolean, true indicates that the local participant is muted, false indicates that a participant is not muted
+   * @param participant A remote participant
+   * @returns Informs if the mute state has changed.
    */
-
   public async mute(
     participant: Participant,
     isMuted: boolean
@@ -223,10 +198,8 @@ export class ConferenceService {
 
   /**
    * Updates the participant's conference permissions.
-   * @param participantPermissions<ParticipantPermissions[]> The set of participant's conference permissions.
-   * @returns {Promise<void>}
+   * @param participantPermissions The set of participant's conference permissions.
    */
-
   public async updatePermissions(
     participantPermissions: Array<ParticipantPermissions>
   ): Promise<void> {
@@ -235,8 +208,7 @@ export class ConferenceService {
 
   /**
    * Starts audio transmission between the local client and a conference.
-   * @param participant<Participant> The participant whose stream should be sent to the local participant.
-   * @returns {Promise<void>}
+   * @param participant The participant whose stream should be sent to the local participant.
    */
 
   public async startAudio(participant: Participant): Promise<void> {
@@ -245,41 +217,33 @@ export class ConferenceService {
 
   /**
    * Notifies the server to either start sending the local participant's video stream to the conference or start sending a remote participant's video stream to the local participant.
-   * @param participant<Participant> The Participant object.
-   * @returns {Promise<void>}
+   * @param participant The Participant object.
    */
-
   public async startVideo(participant: Participant): Promise<void> {
     return this._nativeModule.startVideo(participant);
   }
 
   /**
    * Stops audio transmission between the local client and a conference.
-   * @param participant<Participant> The Participant object.
-   * @returns {Promise<void>}
+   * @param participant The Participant object.
    */
-
   public async stopAudio(participant: Participant): Promise<void> {
     return this._nativeModule.stopAudio(participant);
   }
 
   /**
    * Notifies the server to either stop sending the local participant's video stream to the conference or stop sending a remote participant's video stream to the local participant.
-   * @param participant<Participant> The Participant object.
-   * @returns {Promise<void>}
+   * @param participant The Participant object.
    */
-
   public async stopVideo(participant: Participant): Promise<void> {
     return this._nativeModule.stopVideo(participant);
   }
 
   /**
    * Joins the conference.
-   * @param conference<Conference> The Conference object.
-   * @param options<ConferenceJoinOptions> The additional options for the joining participant.
-   * @returns {Promise<Conference>} Promise with the Conference
+   * @param conference The Conference object.
+   * @param options The additional options for the joining participant.
    */
-
   public async join(
     conference: Conference,
     options?: ConferenceJoinOptions
@@ -291,18 +255,15 @@ export class ConferenceService {
 
   /**
    * Allows the conference owner, or a participant with adequate permissions, to kick another participant from the conference by revoking the conference access token.
-   * @param participant<Participant> The participant who needs to be kicked from the conference.
-   * @returns {Promise<void>}
+   * @param participant The participant who needs to be kicked from the conference.
    */
-
   public async kick(participant: Participant): Promise<void> {
     return this._nativeModule.kick(participant);
   }
 
   /**
    * Leaves the conference.
-   * @param options<ConferenceLeaveOptions> The additional options for the leaving participant.
-   * @returns {Promise<boolean>}
+   * @param options The additional options for the leaving participant.
    */
   public async leave(options?: ConferenceLeaveOptions): Promise<void> {
     await this._nativeModule.leave();
@@ -315,9 +276,9 @@ export class ConferenceService {
   }
 
   /**
-   * Add a handler for conference status changes
-   * @param handler<(data: ConferenceStatusUpdatedEventType) => void> Handling function
-   * @returns {UnsubscribeFunction} Function that removes handler
+   * Adds a listener for conference status changed event
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
   public onStatusChange(
     handler: (data: ConferenceStatusUpdatedEventType) => void
@@ -329,11 +290,10 @@ export class ConferenceService {
   }
 
   /**
-   * Add a handler for permissions changes
-   * @param handler<(data: PermissionsUpdatedEventType) => void> Handling function
-   * @returns {UnsubscribeFunction} Function that removes handler
+   * Adds a listener for permissions changed event
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
-
   public onPermissionsChange(
     handler: (data: PermissionsUpdatedEventType) => void
   ): UnsubscribeFunction {
@@ -344,15 +304,10 @@ export class ConferenceService {
   }
 
   /**
-   * Add a handler for participants changes
-   * @param handler<(data: ParticipantChangedEventType, types?:
-   *    | ConferenceServiceEventNames.ParticipantAdded
-   *    | ConferenceServiceEventNames.ParticipantJoined
-   *    | ConferenceServiceEventNames.ParticipantUpdated
-   *    | ConferenceServiceEventNames.ParticipantRemoved) => void> Handling function
-   * @returns {UnsubscribeFunction} Function that removes handler
+   * Adds a listener for participants changed event
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
-
   public onParticipantsChange(
     handler: (
       data: ParticipantChangedEventType,
@@ -377,14 +332,10 @@ export class ConferenceService {
   }
 
   /**
-   * Add a handler for streams changes
-   * @param handler<(data: StreamChangedEventType type?:
-   *    | ConferenceServiceEventNames.StreamAdded
-   *    | ConferenceServiceEventNames.StreamUpdated
-   *    | ConferenceServiceEventNames.StreamRemoved) => void> Handling function
-   * @returns {UnsubscribeFunction} Function that removes handler
+   * Adds a listener for streams changed event
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
-
   public onStreamsChange(
     handler: (
       data: StreamChangedEventType,
@@ -426,7 +377,6 @@ export class ConferenceService {
    Open your Info.plist file then:
    - add a new DolbyioSdkAppGroupKey as a String type and enter the group name ("YOUR_APP_GROUP")
    - add a new DolbyioSdkPreferredExtensionKey as a String type and enter the broadcast extension bundle id ("YOUR_BROADCAST_EXTENSION_BUNDLE_ID")
-   * @returns {Promise<void>}
    */
   public async startScreenShare(): Promise<void> {
     return this._nativeModule.startScreenShare();
@@ -434,7 +384,6 @@ export class ConferenceService {
 
   /**
    * Stops a screen sharing session.
-   * @returns {Promise<void>}
    */
   public async stopScreenShare(): Promise<void> {
     return this._nativeModule.stopScreenShare();
@@ -442,9 +391,8 @@ export class ConferenceService {
 
   /**
    * Sets the direction a participant is facing in space.
-   * @param participant<Participant> The selected remote participant.
-   * @param direction<SpatialDirection> The direction the local participant is facing in space.
-   * @returns {Promise<void>}
+   * @param participant The selected remote participant.
+   * @param direction The direction the local participant is facing in space.
    */
   public async setSpatialDirection(
     participant: Participant,
@@ -455,11 +403,10 @@ export class ConferenceService {
 
   /**
    * Configures a spatial environment of an application, so the audio renderer understands which directions the application considers forward, up, and right and which units it uses for distance.
-   * @param scale<SpatialScale> The application's distance units or scale in application units per one meter. The value must be greater than 0.
-   * @param forward<SpatialPosition> A vector describing the direction the application considers as forward. The value must be orthogonal to up and right.
-   * @param up<SpatialPosition> A vector describing the direction the application considers as up. The value must be orthogonal to forward and right.
-   * @param right<SpatialPosition> A vector describing the direction the application considers as right. The value must be orthogonal to forward and up.
-   * @returns {Promise<void>}
+   * @param scale The application's distance units or scale in application units per one meter. The value must be greater than 0.
+   * @param forward A vector describing the direction the application considers as forward. The value must be orthogonal to up and right.
+   * @param up A vector describing the direction the application considers as up. The value must be orthogonal to forward and right.
+   * @param right A vector describing the direction the application considers as right. The value must be orthogonal to forward and up.
    */
   public async setSpatialEnvironment(
     scale: SpatialScale,
@@ -472,9 +419,8 @@ export class ConferenceService {
 
   /**
    * Sets a participant's position in space to enable the spatial audio experience during a Dolby Voice conference.
-   * @param participant<Participant> The selected remote participant.
-   * @param position<SpatialPosition> The participant's audio location from which their audio will be rendered.
-   * @returns {Promise<void>}
+   * @param participant The selected remote participant.
+   * @param position The participant's audio location from which their audio will be rendered.
    */
   public async setSpatialPosition(
     participant: Participant,

--- a/src/services/filePresentation/FilePresentationService.ts
+++ b/src/services/filePresentation/FilePresentationService.ts
@@ -11,6 +11,11 @@ import type { FileConverted, File, FilePresentation } from './models';
 
 const { DolbyIoIAPIFilePresentationService } = NativeModules;
 
+/**
+ * The FilePresentationService allows presenting files during a conference.
+ * The Dolby.io Communications APIs service converts the user-provided file into
+ * multiple pages, as images, accessible through the image method.
+ */
 export class FilePresentationService {
   /** @internal */
   _nativeModule = DolbyIoIAPIFilePresentationService;
@@ -20,47 +25,38 @@ export class FilePresentationService {
 
   /**
    * Stops the file presentation.
-   * @returns {Promise<void>}
    */
-
   public async stop(): Promise<void> {
     return this._nativeModule.stop();
   }
 
   /**
    * Starts a file presentation.
-   * @param file<FileConverted> The converted file that the presenter wants to share during the conference.
-   * @returns {Promise<void>}
+   * @param file The converted file that the presenter wants to share during the conference.
    */
-
   public async start(file: FileConverted): Promise<void> {
     return this._nativeModule.start(file);
   }
 
   /**
    * Provides the thumbnail's URL that refers to a specific page of the presented file.
-   * @param page<number> The number of the presented page. Files that do not include any pages, for example jpg images, require setting the value of this parameter to 0.
-   * @returns {Promise<string>}
+   * @param page The number of the presented page. Files that do not include any pages, for example jpg images, require setting the value of this parameter to 0.
    */
-
   public async getThumbnail(page: number): Promise<string> {
     return this._nativeModule.getThumbnail(page);
   }
 
   /**
    * Informs the service to send the updated page number to the conference participants.
-   * @param page<number> The page number that corresponds to the page that should be presented.
-   * @returns {Promise<void>}
+   * @param page The page number that corresponds to the page that should be presented.
    */
-
   public async setPage(page: number): Promise<void> {
     return this._nativeModule.setPage(page);
   }
 
   /**
    * Returns information about the current recording. Use this accessor if you wish to receive information that is available in the Recording object, such as the ID of the participant who started the recording or the timestamp that informs when the recording was started.
-   * @param file<File> 	The file that the presenter wants to share during the conference.
-   * @returns {Promise<FileConverted>} Promise with the FileConverted object.
+   * @param file The file that the presenter wants to share during the conference.
    */
   public async convert(file: File): Promise<FileConverted> {
     return this._nativeModule.convert(file);
@@ -68,7 +64,6 @@ export class FilePresentationService {
 
   /**
    * Gets current file presentation.
-   * @returns {Promise<FilePresentation>} Promise with the FilePresentation object
    */
   public async getCurrent(): Promise<FilePresentation> {
     return this._nativeModule.getCurrent();
@@ -76,17 +71,16 @@ export class FilePresentationService {
 
   /**
    * Downloads and displays locally the presented file by retrieving URLs of the individual images.
-   * @param page<number> The number of the presented page. Files that do not have any pages, for example jpg images, require setting the value of the page parameter to 0.
-   * @returns {Promise<string>}
+   * @param page The number of the presented page. Files that do not have any pages, for example jpg images, require setting the value of the page parameter to 0.
    */
   public async getImage(page: number): Promise<string> {
     return this._nativeModule.getImage(page);
   }
 
   /**
-   * Add a handler for file converted
-   * @param handler<(data: FileConvertedEventType) => void> Handling function
-   * @returns {UnsubscribeFunction} Function that removes handler
+   * Adds a listener for file converted event
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
   public onFileConverted(
     handler: (data: FileConvertedEventType) => void
@@ -98,12 +92,9 @@ export class FilePresentationService {
   }
 
   /**
-   * Add a handler for file presentation changes
-   * @param handler<(data: FilePresentationChangedEventType, type?:
-   *  | FilePresentationServiceEventNames.FilePresentationStarted
-   *  | FilePresentationServiceEventNames.FilePresentationStopped
-   *  | FilePresentationServiceEventNames.FilePresentationUpdated) => void> Handling function
-   * @returns {UnsubscribeFunction} Function that removes handler
+   * Adds a listener for file presentation changed event
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
 
   public onFilePresentationChange(

--- a/src/services/mediaDevice/MediaDeviceService.ts
+++ b/src/services/mediaDevice/MediaDeviceService.ts
@@ -5,13 +5,16 @@ import type { ComfortNoiseLevel } from './models';
 
 const { DolbyIoIAPIMediaDeviceService } = NativeModules;
 
+/**
+ * MediaDeviceService allows the application to manage media devices that are
+ * used during conferences.
+ */
 export class MediaDeviceService {
   /** @internal */
   _nativeModule = DolbyIoIAPIMediaDeviceService;
 
   /**
    * Checks if the application uses the front-facing (true) or back-facing camera (false).
-   * @returns {Promise<boolean>}
    */
   public async isFrontCamera(): Promise<boolean> {
     return this._nativeModule.isFrontCamera();
@@ -19,19 +22,15 @@ export class MediaDeviceService {
 
   /**
    * Retrieves the comfort noise level setting for output devices in Dolby Voice conferences.
-   * @returns {Promise<ComfortNoiseLevel>} Promise with the ComfortNoiseLevel
    */
-
   public async getComfortNoiseLevel(): Promise<ComfortNoiseLevel> {
     return this._nativeModule.getComfortNoiseLevel();
   }
 
   /**
    * Configures the comfort noise level for output devices in Dolby Voice conferences.
-   * @param noiseLevel<ComfortNoiseLevel> The selected comfort noise level.
-   * @returns {Promise<void>}
+   * @param noiseLevel The selected comfort noise level.
    */
-
   public async setComfortNoiseLevel(
     noiseLevel: ComfortNoiseLevel
   ): Promise<void> {
@@ -42,14 +41,12 @@ export class MediaDeviceService {
    * Switches the current camera to another available camera that is connected to the device.
    * @returns {Promise<void}
    */
-
   public async switchCamera(): Promise<void> {
     return this._nativeModule.switchCamera();
   }
 
   /**
    * Switches the current speaker to another available speaker that is connected to the device.
-   * @returns {Promise<void>}
    */
   public async switchSpeaker(): Promise<void> {
     if (Platform.OS === 'android') {

--- a/src/services/notification/NotificationService.ts
+++ b/src/services/notification/NotificationService.ts
@@ -11,6 +11,9 @@ import type { InvitationReceivedEventType } from './events';
 
 const { DolbyIoIAPINotificationService } = NativeModules;
 
+/**
+ * The NotificationService enables inviting participants to a conference.
+ */
 export class NotificationService {
   /** @internal */
   _nativeModule = DolbyIoIAPINotificationService;
@@ -19,9 +22,8 @@ export class NotificationService {
 
   /**
    * Notifies conference participants about a conference invitation.
-   * @param conference<Conference> The conference object.
-   * @param participants<ParticipantInvited[]> Information about the invited application users.
-   * @returns {Promise<void>}
+   * @param conference The conference object.
+   * @param participants Information about the invited application users.
    */
   public async invite(
     conference: Conference,
@@ -32,17 +34,16 @@ export class NotificationService {
 
   /**
    * Declines the conference invitation.
-   * @param conference<Conference> The conference object.
-   * @returns {Promise<void>}
+   * @param conference The conference object.
    */
   public async decline(conference: Conference): Promise<void> {
     return this._nativeModule.decline(conference);
   }
 
   /**
-   * Add a handler for invitation received
-   * @param handler {(data: InvitationReceivedEventType) => void} Handling function
-   * @returns {() => void} Function that removes handler
+   * Add a listener for invitation received event
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
   public onInvitationReceived(
     handler: (data: InvitationReceivedEventType) => void

--- a/src/services/recording/RecordingService.ts
+++ b/src/services/recording/RecordingService.ts
@@ -16,7 +16,6 @@ export class RecordingService {
    * Returns information about the current recording. Use this accessor if you wish to receive information that is
    * available in the Recording object, such as the ID of the participant who started the recording or the timestamp
    * that informs when the recording was started.
-   * @returns {Promise<Recording | null>} Promise with the Recording or null
    */
   public async current(): Promise<Recording | null> {
     return this._nativeModule.current();

--- a/src/services/session/SessionService.ts
+++ b/src/services/session/SessionService.ts
@@ -7,7 +7,8 @@ import { transformToUser } from './transformers';
 const { DolbyIoIAPISessionServiceModule } = NativeModules;
 
 /**
- * The SessionService allows opening and closing sessions. Opening a session is mandatory before interacting with any service.
+ * The SessionService allows opening and closing sessions. Opening a session is
+ * mandatory before interacting with any service.
  */
 
 export class SessionService {
@@ -16,10 +17,9 @@ export class SessionService {
 
   /**
    * Opens a new session.
-   * @param participantInfo [participantInfo={}] The optional information about the local participant.
-   * @returns {Promise<null>}
+   * @param participantInfo The optional information about the local participant.
    */
-  public async open(participantInfo: ParticipantInfo = {}): Promise<null> {
+  public async open(participantInfo: ParticipantInfo = {}): Promise<void> {
     const { name, avatarUrl, externalId } = participantInfo;
     return this._nativeModule.open({
       name,
@@ -30,15 +30,13 @@ export class SessionService {
 
   /**
    * Closes the current session.
-   * @returns {Promise<null>}
    */
-  public async close(): Promise<null> {
+  public async close(): Promise<void> {
     return this._nativeModule.close();
   }
 
   /**
    * Checks whether there is an open session that connects SDK with backend.
-   * @returns {Promise<Boolean>}
    */
   public async isOpen(): Promise<Boolean> {
     return this._nativeModule.isOpen();
@@ -46,7 +44,6 @@ export class SessionService {
 
   /**
    * Gets object of local user
-   * @returns {Promise<User>}
    */
   public async getCurrentUser(): Promise<User> {
     return transformToUser(await this._nativeModule.getParticipant());

--- a/src/services/videoPresentation/VideoPresentationService.ts
+++ b/src/services/videoPresentation/VideoPresentationService.ts
@@ -8,6 +8,11 @@ import type { VideoPresentation, VideoPresentationState } from './models';
 
 const { DolbyIoIAPIVideoPresentationService } = NativeModules;
 
+/**
+ * The VideoPresentationService allows sharing videos during a conference.
+ * To present a video, the conference participant needs to provide the URL that
+ * defines the video location. We recommend sharing files in the MPEG-4 Part 14 or MP4 video formats.
+ */
 export class VideoPresentationService {
   /** @internal */
   _nativeModule = DolbyIoIAPIVideoPresentationService;
@@ -16,8 +21,7 @@ export class VideoPresentationService {
 
   /**
    * Pauses the video presentation.
-   * @param timestamp<number>
-   * @returns void
+   * @param timestamp The timestamp that informs when the video needs to be paused, in milliseconds.
    */
   public pause(timestamp: number): Promise<void> {
     return this._nativeModule.pause(timestamp);
@@ -25,7 +29,6 @@ export class VideoPresentationService {
 
   /**
    * Resumes the paused video presentation.
-   * @returns void
    */
   public play(): Promise<void> {
     return this._nativeModule.play();
@@ -36,7 +39,6 @@ export class VideoPresentationService {
    * if you wish to receive information that is available in the VideoPresentation
    * object, such as information about the participant who shares the video or the
    * URL of the presented video file.
-   * @returns {VideoPresentation | null}
    */
   public current(): Promise<VideoPresentation | null> {
     return this._nativeModule.current();
@@ -44,7 +46,6 @@ export class VideoPresentationService {
 
   /**
    * Provides the current state of the video presentation.
-   * @returns VideoPresentationState
    */
   public state(): Promise<VideoPresentationState> {
     return this._nativeModule.state();
@@ -52,8 +53,7 @@ export class VideoPresentationService {
 
   /**
    * Allows the presenter to navigate to the specific section of the shared video.
-   * @param timestamp<number>
-   * @returns void
+   * @param timestamp The timestamp the presenter wants to start playing the video from, in milliseconds.
    */
   public seek(timestamp: number): Promise<void> {
     return this._nativeModule.seek(timestamp);
@@ -61,8 +61,7 @@ export class VideoPresentationService {
 
   /**
    * Starts the video presentation.
-   * @param url<number>
-   * @returns void
+   * @param url The URL that specifies the video file location.
    */
   public start(url: string): Promise<void> {
     return this._nativeModule.start(url);
@@ -70,7 +69,6 @@ export class VideoPresentationService {
 
   /**
    * Stops the video presentation.
-   * @returns void
    */
   public stop(): Promise<void> {
     return this._nativeModule.stop();
@@ -78,10 +76,8 @@ export class VideoPresentationService {
 
   /**
    * Adds a listener for video presentation started, sought, paused and played events
-   * @param handler {(data: VideoPresentationEventType,
-   * type: VideoPresentationEventNames.started | VideoPresentationEventNames.sought
-       | VideoPresentationEventNames.paused | VideoPresentationEventNames.played) => void} Handling function
-   * @returns {UnsubscribeFunction} Function that unsubscribes from listeners
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
   public onVideoPresentationChange(
     handler: (
@@ -123,8 +119,8 @@ export class VideoPresentationService {
 
   /**
    * Adds a listener for video presentation stopped event
-   * @param handler {() => void} Handling function
-   * @returns {UnsubscribeFunction} Function that unsubscribes from listeners
+   * @param handler Event callback function
+   * @returns Function that unsubscribes from listeners
    */
   onVideoPresentationStopped(handler: () => void): UnsubscribeFunction {
     return this._nativeEvents.addListener(

--- a/src/services/videoPresentation/__tests__/index.test.ts
+++ b/src/services/videoPresentation/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 
-import VideoPresentationService from '../VideoPresentation';
+import VideoPresentationService from '../VideoPresentationService';
 import { VideoPresentationEventNames } from '../events';
 
 const { DolbyIoIAPIVideoPresentationService } = NativeModules;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,10 +2076,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^16.9.19":
-  version "16.14.14"
-  resolved "https://registry.npmjs.org/@types/react/-/react-16.14.14.tgz"
-  integrity sha512-uwIWDYW8LznHzEMJl7ag9St1RsK0gw/xaFZ5+uI1ZM1HndwUgmPH3/wQkSb87GkOVg7shUxnpNW8DcN0AzvG5Q==
+"@types/react@^16.13.1":
+  version "16.14.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.21.tgz#35199b21a278355ec7a3c40003bd6a334bd4ae4a"
+  integrity sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
In this PR I've removed almost all `@return` comments, because when using typescript typedoc automatically generates correct return types - the only `@returns` left are the ones that give more context to returned value.
All param types were also removed per typedoc documentation: 
`The JSDoc param type is not necessary because it will be read from the TypeScript types.`